### PR TITLE
Implement disk collector

### DIFF
--- a/controller/command.go
+++ b/controller/command.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"log"
 	"os/exec"
+	"strings"
 )
 
 func ExecCommand(command string) (out bytes.Buffer) {
-	cmd := exec.Command(command)
+	commandWithArgs := strings.Split(command, " ")
+	cmd := exec.Command(commandWithArgs[0], commandWithArgs[1:]...)
 	cmd.Stdout = &out
 	err := cmd.Run()
 	if err != nil {

--- a/controller/disk.go
+++ b/controller/disk.go
@@ -2,7 +2,9 @@ package controller
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
+	"strings"
 
 	"github.com/robertoduessmann/health-check/model"
 )
@@ -31,8 +33,15 @@ func HardDiskCheck() (hardDisks []model.HardDisk) {
 	diskNames := getDiskNames(devices)
 
 	for _, diskName := range diskNames {
-		// Get "df /dev/diskName" output
-		log.Println(diskName)
+		dfCommand := ExecCommand("df -B1 /dev/" + diskName)
+		dfResult := dfCommand.String()
+		diskInfo, err := parseDf(dfResult)
+		if err != nil {
+			log.Printf("df parse error for /dev/%s: %q", diskName, err)
+			continue
+		}
+		diskInfo.Name = diskName
+		hardDisks = append(hardDisks, diskInfo)
 	}
 
 	return
@@ -58,5 +67,19 @@ func getDiskNames(devices Devices) (diskNames []string) {
 
 func parseLsblk(cmdOutput string) (devices Devices, err error) {
 	err = json.Unmarshal([]byte(cmdOutput), &devices)
+	return
+}
+
+func parseDf(cmdOutput string) (disk model.HardDisk, err error) {
+	lines := strings.Split(cmdOutput, "\n")
+	if len(lines) != 3 { // 3 is empty newline at the end
+		return disk, errors.New("Invalid df output")
+	}
+
+	fields := strings.Fields(lines[1])
+	disk.Total = fields[1]
+	disk.Used = fields[2]
+	disk.Free = fields[3]
+
 	return
 }

--- a/controller/disk.go
+++ b/controller/disk.go
@@ -20,7 +20,7 @@ type DeviceDescriptor struct {
 	Children   []DeviceDescriptor `json:"children"`
 }
 
-func HardDiskCheck() (hardDisks []model.HardDisk) {
+func DisksCheck() (disks []model.Disk) {
 	lsblkCommand := ExecCommand("lsblk --json")
 	lsblkResult := lsblkCommand.String()
 
@@ -35,13 +35,13 @@ func HardDiskCheck() (hardDisks []model.HardDisk) {
 	for _, diskName := range diskNames {
 		dfCommand := ExecCommand("df -B1 /dev/" + diskName)
 		dfResult := dfCommand.String()
-		diskInfo, err := parseDf(dfResult)
+		disk, err := parseDf(dfResult)
 		if err != nil {
 			log.Printf("df parse error for /dev/%s: %q", diskName, err)
 			continue
 		}
-		diskInfo.Name = diskName
-		hardDisks = append(hardDisks, diskInfo)
+		disk.Name = diskName
+		disks = append(disks, disk)
 	}
 
 	return
@@ -70,7 +70,7 @@ func parseLsblk(cmdOutput string) (devices Devices, err error) {
 	return
 }
 
-func parseDf(cmdOutput string) (disk model.HardDisk, err error) {
+func parseDf(cmdOutput string) (disk model.Disk, err error) {
 	lines := strings.Split(cmdOutput, "\n")
 	if len(lines) != 3 { // 3 is empty newline at the end
 		return disk, errors.New("Invalid df output")

--- a/controller/disk.go
+++ b/controller/disk.go
@@ -1,0 +1,62 @@
+package controller
+
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/robertoduessmann/health-check/model"
+)
+
+type Devices struct {
+	BlockDevices []DeviceDescriptor `json:"blockdevices"`
+}
+
+type DeviceDescriptor struct {
+	Mountpoint string             `json:"mountpoint"`
+	Type       string             `json:"type"`
+	Name       string             `json:"name"`
+	Children   []DeviceDescriptor `json:"children"`
+}
+
+func HardDiskCheck() (hardDisks []model.HardDisk) {
+	lsblkCommand := ExecCommand("lsblk --json")
+	lsblkResult := lsblkCommand.String()
+
+	devices, err := parseLsblk(lsblkResult)
+	if err != nil {
+		log.Println("Failed to parse lsblk output")
+		return
+	}
+
+	diskNames := getDiskNames(devices)
+
+	for _, diskName := range diskNames {
+		// Get "df /dev/diskName" output
+		log.Println(diskName)
+	}
+
+	return
+}
+
+func getDiskNames(devices Devices) (diskNames []string) {
+	for _, device := range devices.BlockDevices {
+		if device.Type == "disk" {
+			if device.Mountpoint != "" && device.Mountpoint != "[SWAP]" {
+				diskNames = append(diskNames, device.Name)
+			}
+
+			for _, part := range device.Children {
+				if part.Mountpoint != "" && part.Mountpoint != "[SWAP]" {
+					diskNames = append(diskNames, part.Name)
+				}
+			}
+		}
+	}
+
+	return
+}
+
+func parseLsblk(cmdOutput string) (devices Devices, err error) {
+	err = json.Unmarshal([]byte(cmdOutput), &devices)
+	return
+}

--- a/controller/health.go
+++ b/controller/health.go
@@ -12,6 +12,7 @@ func HealtCheck(w http.ResponseWriter, r *http.Request) {
 
 	var health model.Health
 	health.Memory = MemoryCheck()
+	health.HardDisks = HardDiskCheck()
 
 	fmt.Fprintf(w, string(toJSON(health)))
 }

--- a/controller/health.go
+++ b/controller/health.go
@@ -12,7 +12,7 @@ func HealtCheck(w http.ResponseWriter, r *http.Request) {
 
 	var health model.Health
 	health.Memory = MemoryCheck()
-	health.HardDisks = HardDiskCheck()
+	health.Disks = DisksCheck()
 
 	fmt.Fprintf(w, string(toJSON(health)))
 }

--- a/model/disk.go
+++ b/model/disk.go
@@ -1,6 +1,6 @@
 package model
 
-type HardDisk struct {
+type Disk struct {
 	Name  string `json:"name"`
 	Total string `json:"total"`
 	Used  string `json:"used"`

--- a/model/hardDisk.go
+++ b/model/hardDisk.go
@@ -1,6 +1,7 @@
 package model
 
 type HardDisk struct {
+	Name  string `json:"name"`
 	Total string `json:"total"`
 	Used  string `json:"used"`
 	Free  string `json:"free"`

--- a/model/health.go
+++ b/model/health.go
@@ -1,7 +1,7 @@
 package model
 
 type Health struct {
-	Memory    Memory    `json:"memory"`
-	HardDisk  HardDisk  `json:"hard_disk"`
-	Processor Processor `json:"processor"`
+	Memory    Memory     `json:"memory"`
+	HardDisks []HardDisk `json:"hard_disks"`
+	Processor Processor  `json:"processor"`
 }

--- a/model/health.go
+++ b/model/health.go
@@ -1,7 +1,7 @@
 package model
 
 type Health struct {
-	Memory    Memory     `json:"memory"`
-	HardDisks []HardDisk `json:"hard_disks"`
-	Processor Processor  `json:"processor"`
+	Memory    Memory    `json:"memory"`
+	Disks     []Disk    `json:"disks"`
+	Processor Processor `json:"processor"`
 }


### PR DESCRIPTION
Disk collector scans the system for the block devices that are local disks, mounted and not a swap because these are the only one that can be queried for the space occupied/free.

Health type was modified to hold array of disks because the system will have multiple (several partitions, HDDs, SSDs, USBs, etc.)

Partly fixes #1